### PR TITLE
Some trivial fixes and some new supported backup/restore

### DIFF
--- a/backups/zimbra-backup.sh
+++ b/backups/zimbra-backup.sh
@@ -382,7 +382,7 @@ function zimbraBackupAccountSignatures() {
       # Save the name of the signature in the first line
       # Rename the file to indicate if the signature is html or plain text
       local backup_file="${tmp_backup_file}.${extension}"
-      printf '%s' "${name}" > "${backup_file}"
+      printf '%s\n' "${name}" > "${backup_file}"
 
       # Remove every line corresponding to a Zimbra field and not the signature content itself
       (grep -iv '^zimbra[a-z]\+: ' "${tmp_backup_file}" || true) >> "${backup_file}"

--- a/backups/zimbra-backup.sh
+++ b/backups/zimbra-backup.sh
@@ -279,10 +279,19 @@ function zimbraBackupLists() {
   install -o "${_zimbra_user}" -g "${_zimbra_group}" -d "${backup_path}"
 
   for list_email in $(zimbraGetLists); do
-    local backup_file="${backup_path}/${list_email}"
+    if [ ! -d "${backup_path}/${list_email}" ]; then
+      mkdir -p "${backup_path}/${list_email}"
+    fi
+
+    local backup_file="${backup_path}/${list_email}/members"
 
     log_debug "Backup members of ${list_email}"
     zimbraGetListMembers "${list_email}" | (grep -F @ | grep -v '^#' || true) > "${backup_file}"
+
+    local backup_file="${backup_path}/${list_email}/aliases"
+
+    log_debug "Backup aliases of ${list_email}"
+    zimbraGetListAliases "${list_email}" | (grep -F @ | grep -v '^#' || true) > "${backup_file}"
   done
 }
 

--- a/backups/zimbra-common.inc.sh
+++ b/backups/zimbra-common.inc.sh
@@ -215,6 +215,13 @@ function zimbraGetListMembers() {
   execZimbraCmd cmd
 }
 
+function zimbraGetListAliases() {
+  local list_email="${1}"
+  local cmd=(zmprov --ldap getDistributionList "${list_email}")
+
+  execZimbraCmd cmd | awk ' /^zimbraMailAlias:/ { print $2 } '
+}
+
 function zimbraGetAccounts() {
   local cmd=(zmprov --ldap getAllAccounts)
 
@@ -347,6 +354,14 @@ function zimbraSetListMember() {
   local list_email="${1}"
   local member_email="${2}"
   local cmd=(zmprov addDistributionListMember "${list_email}" "${member_email}")
+
+  execZimbraCmd cmd
+}
+
+function zimbraSetListAlias() {
+  local list_email="${1}"
+  local alias_email="${2}"
+  local cmd=(zmprov addDistributionListAlias "${list_email}" "${alias_email}")
 
   execZimbraCmd cmd
 }

--- a/backups/zimbra-common.inc.sh
+++ b/backups/zimbra-common.inc.sh
@@ -413,6 +413,17 @@ function zimbraSetAccountLock() {
   execZimbraCmd cmd
 }
 
+function zimbraSetAccount() {
+  local email="${1}"
+  local field="${2}"
+  local value="${3}"
+
+  cmd=(zmprov modifyAccount "${email}" "${field}" "${value}")
+
+  execZimbraCmd cmd
+}
+
+
 function zimbraSetAccountCatchAll() {
   local email="${1}"
   local at_domain="${2}"

--- a/backups/zimbra-restore.sh
+++ b/backups/zimbra-restore.sh
@@ -434,6 +434,35 @@ function zimbraRestoreAccountFilters() {
   zimbraSetAccountFilters "${email}" "${backup_file}"
 }
 
+# Restore Out Of Office settings for the account
+function zimbraRestoreAccountOOO() {
+  local ooo_settings="zimbraFeatureOutOfOfficeReplyEnabled
+                      zimbraPrefOutOfOfficeCacheDuration
+                      zimbraPrefOutOfOfficeExternalReply
+                      zimbraPrefOutOfOfficeExternalReplyEnabled
+                      zimbraPrefOutOfOfficeFromDate
+                      zimbraPrefOutOfOfficeReply
+                      zimbraPrefOutOfOfficeReplyEnabled
+                      zimbraPrefOutOfOfficeStatusAlertOnLogin
+                      zimbraPrefOutOfOfficeUntilDate"
+
+  local email="${1}"
+  local backup_path="${_backups_path}/accounts/${email}"
+  local backup_file="${backup_path}/settings"
+
+  if [ ! -f "${backup_file}" -o ! -r "${backup_file}" ]; then
+    log_err "${email}: File <${backup_file}> is missing, is not a regular file or is not readable"
+    log_err "${email}: Account Out Of Office settings will *NOT* be restored"
+    return
+  fi
+
+  for field in $ooo_settings; do
+     local value=$(extractFromAccountSettingsFile $email $field)
+     zimbraSetAccount "${email}" "${field}" "${value}"
+  done
+
+}
+
 # Restore all the data for the account, with folders/mails/tasks/calendar/etc
 function zimbraRestoreAccountData() {
   local email="${1}"
@@ -643,6 +672,9 @@ ${_exclude_accounts} || {
   
           log_debug "${email}: Restore Forwarding setting"
           zimbraRestoreAccountForwarding "${email}"
+
+          log_debug "${email}: Restore OutOfOffice settings"
+          zimbraRestoreAccountOOO "${email}"
         }
     
         ${_exclude_data} || {

--- a/backups/zimbra-restore.sh
+++ b/backups/zimbra-restore.sh
@@ -157,7 +157,7 @@ function extractFromAccountSettingsFile() {
   local email="${1}"
   local field="${2}"
   local backup_file="${_backups_path}/accounts/${email}/settings"
-  local value=$((grep "^${field}:" "${backup_file}" || true) | sed "s/^${field}: //")
+  local value=$( (sed -n -e '/^'$field':/,/^[a-zA-Z0-9]*:/ p' ${backup_file} || true) | sed '$ d' | sed -e 's/^'$field': //g')
 
   printf '%s' "${value}"
 }

--- a/backups/zimbra-restore.sh
+++ b/backups/zimbra-restore.sh
@@ -225,20 +225,42 @@ function zimbraRestoreLists() {
   local lists=$(ls "${backup_path}")
 
   for list_email in ${lists}; do
-    local backup_file="${backup_path}/${list_email}"
+    local backup_list_path="${backup_path}/${list_email}"
 
-    if [ ! -f "${backup_file}" -o ! -r "${backup_file}" ]; then
-      log_err "File <${backup_file}> is not a regular file or is not readable"
+    if [ ! -d "${backup_list_path}" -o ! -x "${backup_list_path}" -o ! -r "${backup_list_path}" ]; then
+      log_err "Directory <$backup_list_path> is not a directory or is not readable"
+      exit 1
+    fi
+
+    local backup_file_members="${backup_list_path}/members"
+
+    if [ ! -f "${backup_file_members}" -o ! -r "${backup_file_members}" ]; then
+      log_err "File <${backup_file_members}> is not a regular file or is not readable"
+      exit 1
+    fi
+
+    local backup_file_aliases="${backup_list_path}/aliases"
+
+    if [ ! -f "${backup_file_aliases}" -o ! -r "${backup_file_aliases}" ]; then
+      log_err "File <${backup_file_aliases}> is not a regular file or is not readable"
       exit 1
     fi
 
     log_debug "Creating mailing list <${list_email}>"
     zimbraCreateList "${list_email}"
 
+    log_debug "Importing mailing list <${list_email}> members"
     while read member_email; do
       log_debug "${list_email}: Add <${member_email}> as a member"
       zimbraSetListMember "${list_email}" "${member_email}"
-    done < "${backup_file}"
+    done < "${backup_file_members}"
+
+    log_debug "Importing mailing list <${list_email}> aliases"
+    while read alias_email; do
+      log_debug "${list_email}: Add <${alias_email}> as an alias"
+      zimbraSetListAlias "${list_email}" "${alias_email}"
+    done < "${backup_file_aliases}"
+
   done
 }
 


### PR DESCRIPTION
Hello,

Thanks for this code :) it's helpful !

- Small fixes:
   - 8248589: extractFromAccountSettingsFile was only able to handle single line values.
   - 809ef8a:  1st line of signature was appended in signature name, and removed from signature.
- New data/parameters import/export:
   - 4d6abe2: Aliases were not handled on distribution lists (only on Accounts)
   - 4262553: Out Of Office parameters were not handled

Probably not very on-par with your coding standards though (quick fix mode) ...

Cheers,
